### PR TITLE
Fix flask not running properly

### DIFF
--- a/helpers/automated_boost.py
+++ b/helpers/automated_boost.py
@@ -247,7 +247,7 @@ def start_sellapp(data):
         pass
 
 def run():
-    app.run(host="0.0.0.0", port="6969", debug=False)
+    app.run(host="0.0.0.0", port=6969, debug=False, use_reloader=False)
      
 def keep_alive():
     t = Thread(target=run)

--- a/main.py
+++ b/main.py
@@ -400,5 +400,5 @@ async def boost(
         os.remove("success.txt")
         os.remove("failed.txt")
     
-#keep_alive()
+keep_alive()
 bot.run(config["token"])


### PR DESCRIPTION
The `keep_alive` function was commented out, and therefore wouldn't run the web server.

Furthermore, flask won't run on a non-main thread without disabling the reloader.